### PR TITLE
Escape whitespace and newlines in regex

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -35,12 +35,12 @@ var App = (function ($) {
 
         if(pane.hasClass('preview')) {
             var content = $(pane.prev()).find('.editor-content').val();
-            var html = content.match(/<code>(.*?)<\/code>/g);
+            var html = content.match(/<code>([\s\S]*?)<\/code>/g);
 
             if(html != null) {
                 html.forEach(function (block) {
                     block = block.replace(/<code[^>]*>/gi, '').replace(/<\/code>/gi, '');
-                    content = content.replace(block, _.escape(block));
+                    content = content.replace(block, _.escape(block).trim());
                 });
             }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -70,7 +70,7 @@ namespace  SmartcatSupport\util {
         $blocks = extract_tags( $str, '<code>', '</code>' );
 
         foreach( $blocks as $block ) {
-            $str = str_replace( $block, htmlentities( $block ), $str );
+            $str = str_replace( $block, trim(  htmlentities( $block ) ), $str );
         }
 
         return $str;


### PR DESCRIPTION
This was caused by white space not being ignored in the regex that parses code tags

![image](https://cloud.githubusercontent.com/assets/20322777/25110896/6d4709c6-23b5-11e7-88db-ddc0f1a85d60.png)

here's how it looks after escaping 

![image](https://cloud.githubusercontent.com/assets/20322777/25110922/998255ea-23b5-11e7-9fbf-9267b9384122.png)
