### PR TITLE
I'm localizing the plugin in Italian language

### DIFF
--- a/assets/admin/admin.js
+++ b/assets/admin/admin.js
@@ -38,7 +38,7 @@ var SupportAdmin = (function (module, $, window) {
 
         $.ucareMediaUploader({
             target: ".image-upload",
-            buttonText: "Select image"
+            buttonText: SupportSystem.select_image
         });
 
         $(".color_picker").wpColorPicker();

--- a/includes/admin/functions-menu.php
+++ b/includes/admin/functions-menu.php
@@ -128,7 +128,8 @@ function enqueue_admin_scripts( $hook ) {
         wp_localize_script( 'support-admin-js',
             'SupportSystem', array(
                 'ajax_url'   => admin_url( 'admin-ajax.php' ),
-                'ajax_nonce' => wp_create_nonce( 'support_ajax' )
+                'ajax_nonce' => wp_create_nonce( 'support_ajax' ),
+                'select_image' => __( 'Select image', 'ucare' )
             )
         );
 

--- a/includes/admin/functions-settings.php
+++ b/includes/admin/functions-settings.php
@@ -347,7 +347,7 @@ function add_settings_fields() {
         'uc-privacy',
         'general',
         array(
-            'label'      => __( 'Users must agree to terms before registering', 'kb' ),
+            'label'      => __( 'Users must agree to terms before registering', 'ucare' ),
             'label_for'  => Options::ENFORCE_TOS,
             'is_checked' => (bool) get_option( Options::ENFORCE_TOS ),
             'attrs'      => array(

--- a/includes/functions-deprecated.php
+++ b/includes/functions-deprecated.php
@@ -339,7 +339,7 @@ function just_now( $stamp ) {
     if( $now->diff( $date )->format( '%i' ) == 0 ) {
         $out = __( 'Just Now', 'ucare' );
     } else {
-        $out = __( human_time_diff( strtotime( $stamp ), current_time( 'timestamp' ) ) . ' ago', 'ucare' );
+        $out = human_time_diff( strtotime( $stamp ), current_time( 'timestamp' ) ) . __( ' ago', 'ucare' );
     }
 
     return $out;

--- a/templates/partials/navbar.php
+++ b/templates/partials/navbar.php
@@ -86,7 +86,7 @@ namespace ucare;
 
                             <li>
                                 <a href="<?php esc_url_e( edit_profile_page_url() ); ?>">
-                                    <span class="glyphicon glyphicon-cog"></span><?php _e( 'Profile', 'ucare' ); ?>
+                                    <span class="glyphicon glyphicon-cog"></span> <?php _e( 'Profile', 'ucare' ); ?>
                                 </a>
                             </li>
 
@@ -96,7 +96,7 @@ namespace ucare;
 
                                 <li>
                                     <a href="<?php echo admin_url( 'admin.php?page=ucare_support' ); ?>" class="alignright background-secondary hover menu-item">
-                                        <span class="glyphicon glyphicon-th-large"></span><?php _e( 'Support Admin', 'ucare' ); ?>
+                                        <span class="glyphicon glyphicon-th-large"></span> <?php _e( 'Support Admin', 'ucare' ); ?>
                                     </a>
 
                                 </li>
@@ -107,7 +107,7 @@ namespace ucare;
 
                             <li>
                                 <a href="<?php echo esc_url( home_url() ); ?>" class="alignright background-secondary hover menu-item">
-                                    <span class="glyphicon glyphicon-globe"></span><?php _e( 'Back to Site', 'ucare' ); ?>
+                                    <span class="glyphicon glyphicon-globe"></span> <?php _e( 'Back to Site', 'ucare' ); ?>
                                 </a>
                             </li>
 
@@ -115,7 +115,7 @@ namespace ucare;
 
                             <li>
                                 <a href="<?php esc_url_e( wp_logout_url( support_page_url() ) ); ?>" class="alignright background-secondary hover menu-item">
-                                    <span class="glyphicon-log-out glyphicon"></span><?php _e( 'Logout', 'ucare' ); ?>
+                                    <span class="glyphicon-log-out glyphicon"></span> <?php _e( 'Logout', 'ucare' ); ?>
                                 </a>
                             </li>
 

--- a/templates/ticket_list.php
+++ b/templates/ticket_list.php
@@ -71,7 +71,7 @@ namespace ucare;
 
                                 <div class="text-muted">
 
-                                    #<?php echo $post->ID; ?> opened by <?php echo get_the_author_meta( 'display_name', $post->post_author ); ?>
+                                    #<?php echo $post->ID; ?> <?php _e( 'opened by', 'ucare' ) ?> <?php echo get_the_author_meta( 'display_name', $post->post_author ); ?>
 
                                     <a class="ticket-email" href="#"><?php echo \ucare\util\author_email( $post ); ?></a>
 


### PR DESCRIPTION
During my translation session, I've noticed a lot of issues with the localization.
I've also fixed a lot of issues with the Pro version, E-mail piping, Customer Support Survey plugins since I've got the Lifetime license.
I would like to bring these updates too, but I don't know which channel is correct.

Also, since I didn't find a solution, there is an issue if the menu panel of uCare Support is localized.

To be precise, the following code:

`        $this->menu_pages = array(
            'root' => new MenuPage(
                array(
                    'type'          => 'menu',
                    'menu_slug'     => 'ucare_support',
                    'menu_title'    => __( 'uCare Support', 'ucare' ),
                    'capability'    => 'manage_support',
                    'position'      => 71,
                    'icon'          => \ucare\plugin_url() . '/assets/images/admin-icon.png',
                    'render'        => false
                )
            ),`

For some reason, editing the above text Poedit, the Pro features, Customer survey and e-mail piping tabs disappear.

loadtextdomain for uCare Pro are inconsistent: most of them have care or ucare-mc. Same for Customer Survey.

I hope that this post helps.